### PR TITLE
DS2_4_MisteryShield20k

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The A2600Nano is a port of the [MiSTer](https://github.com/MiSTer-devel/Atari260
 This project relies on a [M0S Dock µC](https://wiki.sipeed.com/hardware/en/maixzero/m0s/m0s.html) being connected to the Tang Nano 20K.  
 Alternately you can use a [Raspberry Pi Pico](https://www.raspberrypi.com/documentation/microcontrollers/pico-series.html) or [esp32-s2](https://www.espressif.com/en/products/socs/esp32-s2)/[s3](https://www.espressif.com/en/products/socs/esp32-s3) and use the [FPGA companion firmware](http://github.com/harbaum/FPGA-Companion).
 
-There is a nice [case](https://github.com/vossstef/A2600Nano/tree/main/housing3D) available mounting the [MiSTeryNano shield](https://github.com/harbaum/MiSTeryNano/tree/main/board/misteryshield20k) (TN20k + M0S).
+There is a nice [case](https://github.com/vossstef/A2600Nano/tree/main/housing3D) available mounting the [MiSTeryShield20k](https://github.com/harbaum/MiSTeryNano/tree/main/board/misteryshield20k/README.md) (TN20k + M0S).
 
 Original A2600 core by [Retromaster](https://retromaster.wordpress.com/a2601/)  
 All HID, SDcard and µC firmware by [Till Harbaum](http://www.harbaum.org/till/mist)<br>
@@ -28,8 +28,9 @@ Features:
 * [USB Joystick](https://en.wikipedia.org/wiki/Joystick)
 * [USB Gamepad](https://en.wikipedia.org/wiki/Gamepad) Stick as paddle emulation<br>
 * [USB Mouse](https://en.wikipedia.org/wiki/Computer_mouse) as paddle emulation
-* [legacy D9 Joystick](https://en.wikipedia.org/wiki/Atari_CX40_joystick) (Atari / Commodore digital type) [MiSTeryNano shield](https://github.com/harbaum/MiSTeryNano/tree/main/board/misteryshield20k/README.md)<br>
+* [legacy D9 Joystick](https://en.wikipedia.org/wiki/Atari_CX40_joystick) (Atari / Commodore digital type) [MiSTeryShield20k](https://github.com/harbaum/MiSTeryNano/tree/main/board/misteryshield20k/README.md)<br>
 * Joystick emulation on Keyboard [Numpad](https://en.wikipedia.org/wiki/Numeric_keypad)<br>
+* [Dualshock 2 Controller Gamepad](https://en.wikipedia.org/wiki/DualShock) for [MiSTeryShield20k](https://github.com/harbaum/MiSTeryNano/tree/main/board/misteryshield20k/README.md) via spare pinheader
 * [Dualshock 2 Controller Gamepad](https://en.wikipedia.org/wiki/DualShock) Keys & Stick as Joystick<br>
 * [Dualshock 2 Controller Gamepad](https://en.wikipedia.org/wiki/DualShock) Sticks as paddle emulation (analog mode)<br>
 * Cartridge ROM loader [boot default is homebrew 'Hunchy' Chris Walton](https://videogamehomebrew.fandom.com/wiki/Chris_Walton)  
@@ -125,7 +126,13 @@ or<br>
 USB Joystick(s) or Gamepad(s). OSD: **USB #1 Joy** or **USB #2 Joy** <br>
 Also [RII Mini Keyboard i8](http://www.riitek.com/product/220.html) left Multimedia Keys are active if **USB #1 Joy** selected.  <br>
 or<br>
-Dualshock2 Gamepad Stick as Joystick. OSD: **DS #1 Joy** or **DS #2 Joy**
+Dualshock2 Gamepad Stick as Joystick. OSD: **DS #1 Joy** or **DS #2 Joy**<br>
+> [!IMPORTANT]
+> In a [MiSTeryShield20k](https://github.com/harbaum/MiSTeryNano/tree/main/board/misteryshield20k) configuration Dualshock is supported via the internal ``spare J7`` pinheader. <br>
+> See MiSTeryShield20k [DS Adapter Cable](shield_ds_cable.md) for further information.<br>
+> TN20k: You have to select OSD "DS2 **#2** Joy" for a ``MiSTeryShield20k`` configuration.<br>
+> TN20k: You have to select OSD "DS2 **#1** Joy" if you use a ``Sipeed Joy to DIP`` adapter.<br>
+
 <br>**left stick** for Move and ```square triangle cross circle``` Buttons for Trigger:<br>
 | Buttons | - | - |
 | -       | - | -  |
@@ -144,9 +151,9 @@ or<br> Keyboard Numpad. OSD: **Numpad**<br>
 or<br> Mouse. OSD: **Mouse**<br>
 ```left Mouse Button``` and ```right Mouse Button``` as Trigger for Paddle 1 or 2.<br>
 
-or<br> Dualshock2 Gamepad left stick as Paddle. OSD: **DS #1 Paddle** or **DS #2 Paddle**<br>
+or<br> Dualshock2 Gamepad left stick as Paddle. OSD: **DS #1 Joy** or **DS #2 Joy**<br>
 **cross / triangle** Trigger<br>
-You have first to set the DS2 Sticks into analog mode by pressing the DS2 ANALOG button.<br> Mode indicated by red light indicator.<br>Configure DIGITAL mode (press ANALOG button again) when using the **Joystick** mode again.<br>
+You have first to set the DS2 Sticks into **analog mode** by pressing the DS2 ANALOG button.<br> Mode indicated by red light indicator.<br>Configure DIGITAL mode (press ANALOG button again) when using the **Joystick** mode again.<br>
 
 ## LED UI
 

--- a/README.md
+++ b/README.md
@@ -130,10 +130,13 @@ Dualshock2 Gamepad Stick as Joystick. OSD: **DS #1 Joy** or **DS #2 Joy**<br>
 > [!IMPORTANT]
 > In a [MiSTeryShield20k](https://github.com/harbaum/MiSTeryNano/tree/main/board/misteryshield20k) configuration Dualshock is supported via the internal ``spare J7`` pinheader. <br>
 > See MiSTeryShield20k [DS Adapter Cable](shield_ds_cable.md) for further information.<br>
-> TN20k: You have to select OSD "DS2 **#2** Joy" for a ``MiSTeryShield20k`` configuration.<br>
-> TN20k: You have to select OSD "DS2 **#1** Joy" if you use a ``Sipeed Joy to DIP`` adapter.<br>
 
-<br>**left stick** for Move and ```square triangle cross circle``` Buttons for Trigger:<br>
+> [!NOTE]
+> TN20k: You have to select OSD "DS2 **#2** Joy" for a ``MiSTeryShield20k`` configuration.<br>
+> TN20k: You have to select OSD "DS2 **#1** Joy" if you use the ``Sipeed Joy to DIP`` adapter.<br>
+Both DS interface ports can be active at the same time meaning twin Dualshock support if the MiSTeryShield20k MIDI interface is not populated (Resistor R9 and IC U3 removed).  
+
+<br>**left stick** or **D-Pad** for Move and ```square triangle cross circle``` Buttons for Trigger:<br>
 | Buttons | - | - |
 | -       | - | -  |
 | square<br>Trigger 1 | Up  | cross<br>Trigger 2 |

--- a/src/a2600_top_tn20k.cst
+++ b/src/a2600_top_tn20k.cst
@@ -107,7 +107,7 @@ IO_PORT "sd_dat[3]" PULL_MODE=NONE IO_TYPE=LVCMOS33;
 IO_LOC "ws2812" 79;
 IO_PORT "ws2812" PULL_MODE=DOWN IO_TYPE=LVCMOS33;
 
-// Joystick DS 2
+// Joystick DS 2 using Sipeed Joystick to DIP Adapter
 IO_LOC "ds_clk" 52;
 IO_PORT "ds_clk" PULL_MODE=UP IO_TYPE=LVCMOS33;
 IO_LOC "ds_mosi" 53;
@@ -117,3 +117,12 @@ IO_PORT "ds_miso" PULL_MODE=UP IO_TYPE=LVCMOS33;
 IO_LOC "ds_cs"  72;
 IO_PORT "ds_cs" PULL_MODE=UP IO_TYPE=LVCMOS33;
 
+// Joystick DS 2 using Spare Header on MisteryShield20k
+IO_LOC "ds_clk_ms20k" 73;
+IO_PORT "ds_clk_ms20k" PULL_MODE=UP IO_TYPE=LVCMOS33;
+IO_LOC "ds_mosi_ms20k" 74;
+IO_PORT "ds_mosi_ms20k" PULL_MODE=UP IO_TYPE=LVCMOS33;
+IO_LOC "ds_miso_ms20k" 77;
+IO_PORT "ds_miso_ms20k" PULL_MODE=UP IO_TYPE=LVCMOS33; 
+IO_LOC "ds_cs_ms20k" 31;
+IO_PORT "ds_cs_ms20k" PULL_MODE=UP IO_TYPE=LVCMOS33;

--- a/src/a2600_top_tn20k.sdc
+++ b/src/a2600_top_tn20k.sdc
@@ -1,5 +1,6 @@
 create_clock -name clk_27mhz -period 37.037 -waveform {0 5} [get_ports {clk_27mhz}]
-create_clock -name ds2_clk -period 8000 -waveform {0 5} [get_nets {gamepad/clk_spi}]
+create_clock -name ds_clk -period 8000 -waveform {0 5} [get_nets {gamepad_p1/clk_spi}]
+create_clock -name ds2_clk_ms20k -period 8000 -waveform {0 5} [get_nets {gamepad_p2/clk_spi}]
 create_clock -name clk -period 34.722 -waveform {0 5} [get_nets {clk}]
 create_clock -name clk_14 -period 70 -waveform {0 5} [get_nets {clk_14}]
 create_clock -name clk_cpu -period 279.408 -waveform {0 5} [get_nets {clk_cpu}]


### PR DESCRIPTION
Dualshock for MisteryShield20k via spare pinheader.
Use OSD "DS2 #2 Joy" to select the spare header as Game input control port.

Idea for the feature from [venice1200](https://github.com/venice1200). Thanks !
